### PR TITLE
Add a `services` key in the bundle configuration

### DIFF
--- a/Profideo/FormulaInterpreterBundle/DependencyInjection/Configuration.php
+++ b/Profideo/FormulaInterpreterBundle/DependencyInjection/Configuration.php
@@ -104,6 +104,32 @@ class Configuration implements ConfigurationInterface
                         ->requiresAtLeastOneElement()
                         ->prototype('scalar')->end()
                     ->end()
+
+                    ->arrayNode('services')
+                        ->defaultValue(array())
+                        ->beforeNormalization()
+                            ->ifArray()
+                                ->then(function($values) {
+                                    $services = array();
+
+                                    foreach ($values as $value) {
+                                        $services[] = array('method' => $value[0], 'parameters' => $value[1]);
+                                    }
+
+                                    return $services;
+                                })
+                            ->end()
+                        ->prototype('array')
+                            ->children()
+                                ->scalarNode('method')->end()
+                                ->arrayNode('parameters')
+                                    ->isRequired()
+                                    ->requiresAtLeastOneElement()
+                                    ->prototype('scalar')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/Profideo/FormulaInterpreterBundle/DependencyInjection/ProfideoFormulaInterpreterExtension.php
+++ b/Profideo/FormulaInterpreterBundle/DependencyInjection/ProfideoFormulaInterpreterExtension.php
@@ -78,7 +78,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     $functionDefinition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
 
                     foreach ($function['services'] as $service) {
-                        $parameters = [];
+                        $parameters = array();
 
                         foreach ($service['parameters'] as $parameter) {
                             $parameters[] = new Reference(ltrim($parameter, '@'));

--- a/Profideo/FormulaInterpreterBundle/DependencyInjection/ProfideoFormulaInterpreterExtension.php
+++ b/Profideo/FormulaInterpreterBundle/DependencyInjection/ProfideoFormulaInterpreterExtension.php
@@ -5,6 +5,7 @@ namespace Profideo\FormulaInterpreterBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -74,7 +75,17 @@ class ProfideoFormulaInterpreterExtension extends Extension
                         $function['arguments']['max'],
                     ));
                     $functionDefinition->setPublic(false);
-                    $functionDefinition->addMethodCall('setContainer', [new Reference('service_container')]);
+                    $functionDefinition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
+
+                    foreach ($function['services'] as $service) {
+                        $parameters = [];
+
+                        foreach ($service['parameters'] as $parameter) {
+                            $parameters[] = new Reference(ltrim($parameter, '@'));
+                        }
+
+                        $functionDefinition->addMethodCall($service['method'], $parameters);
+                    }
 
                     $functionService = sprintf('%s.%s', $this->excelFunctionBaseName, $translation);
                     $container->setDefinition($functionService, $functionDefinition);
@@ -158,6 +169,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => -1,
                 ),
                 'translations' => array('AND', 'ET'),
+                'services' => array(),
             ),
             'concatenate' => array(
                 'class' => 'Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\ConcatenateExpressionFunction',
@@ -166,6 +178,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => -1,
                 ),
                 'translations' => array('CONCATENATE', 'CONCATENER'),
+                'services' => array(),
             ),
             'if' => array(
                 'class' => 'Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\IfExpressionFunction',
@@ -174,6 +187,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => 3,
                 ),
                 'translations' => array('IF', 'SI'),
+                'services' => array(),
             ),
             'max' => array(
                 'class' => 'Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\MaxExpressionFunction',
@@ -182,6 +196,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => -1,
                 ),
                 'translations' => array('MAX'),
+                'services' => array(),
             ),
             'min' => array(
                 'class' => 'Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\MinExpressionFunction',
@@ -190,6 +205,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => -1,
                 ),
                 'translations' => array('MIN'),
+                'services' => array(),
             ),
             'or' => array(
                 'class' => 'Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\OrExpressionFunction',
@@ -198,6 +214,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => -1,
                 ),
                 'translations' => array('OR', 'OU'),
+                'services' => array(),
             ),
             'pow' => array(
                 'class' => 'Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\PowExpressionFunction',
@@ -206,6 +223,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => 2,
                 ),
                 'translations' => array('POW', 'PUISSANCE'),
+                'services' => array(),
             ),
             'round' => array(
                 'class' => 'Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\RoundExpressionFunction',
@@ -214,6 +232,7 @@ class ProfideoFormulaInterpreterExtension extends Extension
                     'max' => 2,
                 ),
                 'translations' => array('ROUND', 'ARRONDI'),
+                'services' => array(),
             ),
         );
     }

--- a/Profideo/FormulaInterpreterBundle/Excel/ExpressionLanguage/ExpressionFunction/ExpressionFunction.php
+++ b/Profideo/FormulaInterpreterBundle/Excel/ExpressionLanguage/ExpressionFunction/ExpressionFunction.php
@@ -3,7 +3,6 @@
 namespace Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction;
 
 use Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionError;
-use Symfony\Component\DependencyInjection\Container;
 use Profideo\Component\ExpressionLanguage\ExpressionFunction as BaseExpressionFunction;
 
 /**
@@ -25,11 +24,6 @@ use Profideo\Component\ExpressionLanguage\ExpressionFunction as BaseExpressionFu
  */
 abstract class ExpressionFunction extends BaseExpressionFunction
 {
-    /**
-     * @var Container
-     */
-    protected $container;
-
     /**
      * @var int
      */
@@ -65,18 +59,6 @@ abstract class ExpressionFunction extends BaseExpressionFunction
                 return call_user_func_array([$this, 'getEvaluatorFunction'], func_get_args());
             }
         );
-    }
-
-    /**
-     * @param Container $container
-     *
-     * @return ExpressionFunction
-     */
-    public function setContainer(Container $container)
-    {
-        $this->container = $container;
-
-        return $this;
     }
 
     /**

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/ExcelExpressionLanguageTest.php
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/ExcelExpressionLanguageTest.php
@@ -5,6 +5,7 @@ namespace Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage;
 use Profideo\FormulaInterpreterBundle\Tests\AbstractProfideoFormulaInterpreterExtensionTest;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class ExcelExpressionLanguageTest extends AbstractProfideoFormulaInterpreterExtensionTest
@@ -916,5 +917,23 @@ class ExcelExpressionLanguageTest extends AbstractProfideoFormulaInterpreterExte
         if (!$exception) {
             $this->assertSame($result, $expectedResult);
         }
+    }
+
+    public function testServicesConfig()
+    {
+        $serviceTest1 = new Definition();
+        $serviceTest1->setClass('Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures\ServiceTest1');
+        $this->container->setDefinition('profideo_formula_interpreter.test1', $serviceTest1);
+
+        $serviceTest2 = new Definition();
+        $serviceTest2->setClass('Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures\ServiceTest2');
+        $this->container->setDefinition('profideo_formula_interpreter.test2', $serviceTest2);
+
+        $this->loadConfiguration($this->container, 'config-4');
+        $this->container->compile();
+
+        $formulaInterpreter = $this->container->get('profideo.formula_interpreter.excel.test4');
+
+        $this->assertSame('test 1 test 2', $formulaInterpreter->evaluate('test()'));
     }
 }

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/ExcelExpressionLanguageTest.php
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/ExcelExpressionLanguageTest.php
@@ -929,11 +929,15 @@ class ExcelExpressionLanguageTest extends AbstractProfideoFormulaInterpreterExte
         $serviceTest2->setClass('Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures\ServiceTest2');
         $this->container->setDefinition('profideo_formula_interpreter.test2', $serviceTest2);
 
+        $serviceTest3 = new Definition();
+        $serviceTest3->setClass('Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures\ServiceTest3');
+        $this->container->setDefinition('profideo_formula_interpreter.test3', $serviceTest3);
+
         $this->loadConfiguration($this->container, 'config-4');
         $this->container->compile();
 
         $formulaInterpreter = $this->container->get('profideo.formula_interpreter.excel.test4');
 
-        $this->assertSame('test 1 test 2', $formulaInterpreter->evaluate('test()'));
+        $this->assertSame('test 1 test 2 test 3', $formulaInterpreter->evaluate('test()'));
     }
 }

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/ServiceTest1.php
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/ServiceTest1.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures;
+
+class ServiceTest1
+{
+    public function getTest()
+    {
+        return 'test 1';
+    }
+}

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/ServiceTest2.php
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/ServiceTest2.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures;
+
+class ServiceTest2
+{
+    public function getTest()
+    {
+        return 'test 2';
+    }
+}

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/ServiceTest3.php
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/ServiceTest3.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures;
+
+class ServiceTest3
+{
+    public function getTest()
+    {
+        return 'test 3';
+    }
+}

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/TestExpressionFunction.php
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/TestExpressionFunction.php
@@ -16,6 +16,11 @@ class TestExpressionFunction extends ExpressionFunction
      */
     private $serviceTest2;
 
+    /**
+     * @var ServiceTest3
+     */
+    private $serviceTest3;
+
     protected function getCompilerFunction()
     {
         return sprintf('%s()', $this->getName());
@@ -23,12 +28,13 @@ class TestExpressionFunction extends ExpressionFunction
 
     protected function getEvaluatorFunction()
     {
-        return "{$this->serviceTest1->getTest()} {$this->serviceTest2->getTest()}";
+        return "{$this->serviceTest1->getTest()} {$this->serviceTest2->getTest()} {$this->serviceTest3->getTest()}";
     }
 
-    public function setTest1(ServiceTest1 $serviceTest1)
+    public function setTest13(ServiceTest1 $serviceTest1, ServiceTest3 $serviceTest3)
     {
         $this->serviceTest1 = $serviceTest1;
+        $this->serviceTest3 = $serviceTest3;
 
         return $this;
     }

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/TestExpressionFunction.php
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/TestExpressionFunction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures;
+
+use Profideo\FormulaInterpreterBundle\Excel\ExpressionLanguage\ExpressionFunction\ExpressionFunction;
+
+class TestExpressionFunction extends ExpressionFunction
+{
+    /**
+     * @var ServiceTest1
+     */
+    private $serviceTest1;
+
+    /**
+     * @var ServiceTest2
+     */
+    private $serviceTest2;
+
+    protected function getCompilerFunction()
+    {
+        return sprintf('%s()', $this->getName());
+    }
+
+    protected function getEvaluatorFunction()
+    {
+        return "{$this->serviceTest1->getTest()} {$this->serviceTest2->getTest()}";
+    }
+
+    public function setTest1(ServiceTest1 $serviceTest1)
+    {
+        $this->serviceTest1 = $serviceTest1;
+
+        return $this;
+    }
+
+    public function setTest2(ServiceTest2 $serviceTest2)
+    {
+        $this->serviceTest2 = $serviceTest2;
+
+        return $this;
+    }
+}

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/Yaml/config-4.yml
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/Yaml/config-4.yml
@@ -8,7 +8,7 @@ profideo_formula_interpreter:
                     max: 0
                 translations: [test]
                 services:
-                    - [setTest1, [@profideo_formula_interpreter.test1]]
+                    - [setTest13, [@profideo_formula_interpreter.test1, @profideo_formula_interpreter.test3]]
                     - [setTest2, [@profideo_formula_interpreter.test2]]
         scopes:
             test4:

--- a/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/Yaml/config-4.yml
+++ b/Profideo/FormulaInterpreterBundle/Tests/Excel/ExpressionLanguage/Fixtures/Yaml/config-4.yml
@@ -1,0 +1,17 @@
+profideo_formula_interpreter:
+    excel:
+        functions:
+            test:
+                class: Profideo\FormulaInterpreterBundle\Tests\Excel\ExpressionLanguage\Fixtures\TestExpressionFunction
+                arguments:
+                    min: 0
+                    max: 0
+                translations: [test]
+                services:
+                    - [setTest1, [@profideo_formula_interpreter.test1]]
+                    - [setTest2, [@profideo_formula_interpreter.test2]]
+        scopes:
+            test4:
+                functions: [test]
+                start_with_equal: false
+                minimum_number_of_functions: 0


### PR DESCRIPTION
The idea here is to remove the `container` injection in `ExpressionFunction` and providing a way to call methods instead, in the same way as the `calls` service configuration key.
